### PR TITLE
fix: add build target 'es2017' to vite.config.plugin.ts

### DIFF
--- a/vite.config.plugin.ts
+++ b/vite.config.plugin.ts
@@ -14,6 +14,7 @@ export default defineConfig({
     }),
   ],
   build: {
+    target: "es2017",
     lib: {
       name: figmaManifest.name,
       entry: path.resolve(__dirname, "./src/plugin/plugin.ts"),


### PR DESCRIPTION
Thank you for starting the figma-plugin-react-vite boilerplate project. While using this boilerplate, I found a problem with using object-rest-read, so I fixed vite.config.plugin.ts.

### Changes

- Add build target option 'es2017' to vite.config.plugin.ts
  - https://babeljs.io/docs/babel-plugin-transform-object-rest-spread

<img width="1024" alt="스크린샷 2024-01-07 오후 11 36 59" src="https://github.com/CoconutGoodie/figma-plugin-react-vite/assets/33021438/fc3ead51-e911-41b4-ae10-a2ddbefc1c4e">
