### PR TITLE
Updated to manifest - allow google fonts and support for dynamic page loading

### DIFF
--- a/figma.manifest.ts
+++ b/figma.manifest.ts
@@ -8,4 +8,8 @@ export default {
   capabilities: [],
   enableProposedApi: false,
   editorType: ["figma", "figjam"],
+  networkAccess: {
+    "allowedDomains": [ "https://fonts.googleapis.com", "https://fonts.gstatic.com" ] 
+  },
+  documentAccess: "dynamic-page",
 };


### PR DESCRIPTION
I added Google fonts to the allowed domains array. Also added [documentAccess : "dynamic page](https://www.figma.com/plugin-docs/manifest/#documentaccess)" to support dynamic page loading